### PR TITLE
[Fix] Handle fused tokens in feed and reveal pipeline

### DIFF
--- a/libs/contract-client/src/lib/feed/usePublicFeed.spec.ts
+++ b/libs/contract-client/src/lib/feed/usePublicFeed.spec.ts
@@ -44,9 +44,11 @@ describe('usePublicFeed', () => {
 
     const revealedFilter = Symbol('revealed');
     const mintFilter = Symbol('mint');
+    const fusedFilter = Symbol('fused');
 
     const MintRequested = jest.fn((..._args: unknown[]) => mintFilter);
     const TokenRevealed = jest.fn(() => revealedFilter);
+    const Fused = jest.fn(() => fusedFilter);
 
     const queryFilter = jest.fn(async (filter: unknown) => {
       if (filter === revealedFilter) {
@@ -69,13 +71,16 @@ describe('usePublicFeed', () => {
           { args: { tokenId: 5n, minter: '0xBBB' } },
         ];
       }
+      if (filter === fusedFilter) {
+        return [];
+      }
       return [];
     });
 
     const getAffixes = jest.fn(async () => [0n, 1n, 2n]);
 
     mockedUseReadAffixContract.mockReturnValue({
-      filters: { MintRequested, TokenRevealed },
+      filters: { MintRequested, TokenRevealed, Fused },
       queryFilter,
       getAffixes,
     } as never);
@@ -95,5 +100,72 @@ describe('usePublicFeed', () => {
     expect(Array.isArray(arg)).toBe(true);
     expect(arg).toEqual(expect.arrayContaining([7n, 5n]));
     expect((arg as bigint[]).length).toBe(2);
+  });
+
+  it('drops tokens that were burned by fuse() before reading getAffixes', async () => {
+    process.env.NEXT_PUBLIC_DEPLOYMENT_BLOCK = '100';
+    process.env.NEXT_PUBLIC_RPC_URL = 'https://example.invalid';
+
+    const revealedFilter = Symbol('revealed');
+    const mintFilter = Symbol('mint');
+    const fusedFilter = Symbol('fused');
+
+    const MintRequested = jest.fn((..._args: unknown[]) => mintFilter);
+    const TokenRevealed = jest.fn(() => revealedFilter);
+    const Fused = jest.fn(() => fusedFilter);
+
+    const queryFilter = jest.fn(async (filter: unknown) => {
+      if (filter === revealedFilter) {
+        return [
+          {
+            args: { tokenId: 11n, uri: 'ipfs://eleven' },
+            blockNumber: 200,
+            index: 0,
+          },
+          {
+            args: { tokenId: 12n, uri: 'ipfs://twelve' },
+            blockNumber: 201,
+            index: 0,
+          },
+        ];
+      }
+      if (filter === mintFilter) {
+        return [{ args: { tokenId: 12n, minter: '0xCCC' } }];
+      }
+      if (filter === fusedFilter) {
+        return [
+          {
+            args: {
+              burnedTokenIds: [11n, 8n, 9n, 10n, 6n],
+              newTokenId: 20n,
+              minter: '0xDDD',
+            },
+          },
+        ];
+      }
+      return [];
+    });
+
+    const getAffixes = jest.fn(async () => [0n]);
+
+    mockedUseReadAffixContract.mockReturnValue({
+      filters: { MintRequested, TokenRevealed, Fused },
+      queryFilter,
+      getAffixes,
+    } as never);
+
+    mockedCreateReadProvider.mockReturnValue({
+      getBlock: jest.fn(async (bn: number) => ({
+        timestamp: BigInt(1_700_000_000 + bn),
+      })),
+    } as never);
+
+    const { result } = renderHook(() => usePublicFeed());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(getAffixes).toHaveBeenCalledTimes(1);
+    expect(getAffixes).toHaveBeenCalledWith(12n);
+    expect(getAffixes).not.toHaveBeenCalledWith(11n);
   });
 });

--- a/libs/contract-client/src/lib/feed/usePublicFeed.ts
+++ b/libs/contract-client/src/lib/feed/usePublicFeed.ts
@@ -62,17 +62,27 @@ export function usePublicFeed(): UsePublicFeedResult {
       try {
         const fromBlock = deploymentBlock();
         const revealedFilter = contract.filters.TokenRevealed();
-        const revealedEvents = await contract.queryFilter(
-          revealedFilter,
-          fromBlock,
-        );
+        const fusedFilter = contract.filters.Fused();
+        const [revealedEvents, fusedEvents] = await Promise.all([
+          contract.queryFilter(revealedFilter, fromBlock),
+          contract.queryFilter(fusedFilter, fromBlock),
+        ]);
 
-        const reveals: RawReveal[] = revealedEvents.map((e) => ({
-          tokenId: e.args.tokenId,
-          uri: e.args.uri,
-          blockNumber: e.blockNumber,
-          logIndex: e.index,
-        }));
+        // Tokens consumed by fuse() are burned, so subsequent getAffixes/tokenURI
+        // reads revert. Drop them before the contract reads below.
+        const burned = new Set<bigint>();
+        for (const e of fusedEvents) {
+          for (const id of e.args.burnedTokenIds) burned.add(id);
+        }
+
+        const reveals: RawReveal[] = revealedEvents
+          .filter((e) => !burned.has(e.args.tokenId))
+          .map((e) => ({
+            tokenId: e.args.tokenId,
+            uri: e.args.uri,
+            blockNumber: e.blockNumber,
+            logIndex: e.index,
+          }));
 
         reveals.sort(
           (a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex,

--- a/libs/contract-client/src/lib/fuse/useFuse.ts
+++ b/libs/contract-client/src/lib/fuse/useFuse.ts
@@ -85,6 +85,17 @@ export function useFuse(): UseFuseResult {
           });
           return;
         }
+        // Kick the reveal relayer for the new token's mint block. Without this
+        // the off-chain pipeline only runs on cron, so fuse outputs sit
+        // unrevealed (no `setTokenURI` → no `TokenRevealed` → not in feed).
+        try {
+          const fuseBlock = Number(receipt.blockNumber);
+          await fetch(
+            `/api/reveal/watch?fromBlock=${fuseBlock}&toBlock=${fuseBlock}`,
+          );
+        } catch {
+          // watch endpoint may not be running
+        }
         setStatus({ kind: 'success', txHash: tx.hash, newTokenId });
       } catch (err) {
         setStatus({ kind: 'error', message: mapFuseError(err) });


### PR DESCRIPTION
## Summary
- Filter tokens burned by `fuse()` out of the public feed query — without this, `getAffixes(tokenId)` reverts with `AffixNFT: nonexistent token` and the entire `Promise.all` for the feed fails. Fix queries `Fused` events alongside `TokenRevealed` and excludes any `tokenId` listed in a Fused event's `burnedTokenIds`.
- Kick the off-chain reveal relayer after a successful fuse — `useFuse` now mirrors `useAffixNFT.doMint` by hitting `/api/reveal/watch?fromBlock=B&toBlock=B` for the receipt block, so fused outputs no longer sit unrevealed (no `setTokenURI` → no `TokenRevealed` → not in feed).

## Test plan
- [ ] Load `/feed` while there is a fused (burned) reveal in history — feed renders without the contract-revert error and the burned token does not appear as a card.
- [ ] On `/fuse`, fuse 5 eligible tokens; after the success toast, navigate to `/gallery/<newTokenId>` — the card renders with image and affixes (no permanent "Revealing…").
- [ ] After the fuse from the previous step, refresh `/feed` — the new fused token is listed.
- [ ] `pnpm nx typecheck contract-client` passes.
- [ ] `pnpm nx lint contract-client` passes (no new warnings).